### PR TITLE
oauth : signature invalide

### DIFF
--- a/change.xml
+++ b/change.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://www.rbs.fr/schema/change-component/1.0 http://www.rbschange.fr/static/schema/change-component/1.0.xsd">
 	<name>framework</name>
 	<type>change-lib</type>
-	<version>3.6.7</version>
+	<version>3.6.8</version>
 	<description>Framework Change</description>
 	<license>os</license>
 	<repository>public</repository>
@@ -54,7 +54,7 @@
 		<dependency>
 			<name>lib/icons</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
@@ -75,182 +75,182 @@
 		<dependency>
 			<name>change-module/webservices</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/contactcard</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/filter</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/form</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/markergas</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/skin</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/useractionlogger</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/uixul</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/list</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/media</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/notification</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/generic</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/preferences</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/mysqlindexer</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/solrsearch</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/rss</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/seo</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/dashboard</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/task</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 		
 		<dependency>
 			<name>change-module/theme</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/i18n</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/users</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/website</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/workflow</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 		
 		<dependency>
 			<name>change-module/zone</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 		
 		<dependency>
 			<name>change-module/updater</name>
 			<versions>
-				<version>3.6.7</version>
+				<version>3.6.8</version>
 			</versions>
 		</dependency>
 	</dependencies>

--- a/change.xml
+++ b/change.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://www.rbs.fr/schema/change-component/1.0 http://www.rbschange.fr/static/schema/change-component/1.0.xsd">
 	<name>framework</name>
 	<type>change-lib</type>
-	<version>3.6.8</version>
+	<version>3.6.7</version>
 	<description>Framework Change</description>
 	<license>os</license>
 	<repository>public</repository>
@@ -54,7 +54,7 @@
 		<dependency>
 			<name>lib/icons</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
@@ -75,182 +75,182 @@
 		<dependency>
 			<name>change-module/webservices</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/contactcard</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/filter</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/form</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/markergas</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/skin</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/useractionlogger</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/uixul</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/list</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/media</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/notification</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/generic</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/preferences</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/mysqlindexer</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/solrsearch</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/rss</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/seo</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/dashboard</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/task</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 		
 		<dependency>
 			<name>change-module/theme</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/i18n</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/users</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/website</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 
 		<dependency>
 			<name>change-module/workflow</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 		
 		<dependency>
 			<name>change-module/zone</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 		
 		<dependency>
 			<name>change-module/updater</name>
 			<versions>
-				<version>3.6.8</version>
+				<version>3.6.7</version>
 			</versions>
 		</dependency>
 	</dependencies>

--- a/f_web/oauth/Request.class.php
+++ b/f_web/oauth/Request.class.php
@@ -281,6 +281,7 @@ class f_web_oauth_Request
 		}
 		
 		ksort($mergedRequest);
+		parse_str(http_build_query($mergedRequest, "", "&"), $mergedRequest);
 		foreach ($mergedRequest as $name => $value)
 		{
 			sort($value);

--- a/indexer/SolrManager.class.php
+++ b/indexer/SolrManager.class.php
@@ -326,13 +326,13 @@ class indexer_SolrManager
 					// Add the client field
 					$this->xmlWriterAdd->startElement('field');
 					$this->xmlWriterAdd->writeAttribute('name', 'client');
-					$this->xmlWriterAdd->text($this->xmlentities($this->getClientId()));
+					$this->xmlWriterAdd->text($this->getClientId());
 					$this->xmlWriterAdd->endElement();
 					
 					// Build the finalId
 					$this->xmlWriterAdd->startElement('field');
 					$this->xmlWriterAdd->writeAttribute('name', 'finalId');
-					$this->xmlWriterAdd->text($this->xmlentities(strval($this->getClientId() . $values[0])));
+					$this->xmlWriterAdd->text(strval($this->getClientId() . $values[0]));
 					$this->xmlWriterAdd->endElement();
 					break;
 				case 'lang':
@@ -348,7 +348,7 @@ class indexer_SolrManager
 			{
 				$this->xmlWriterAdd->startElement('field');
 				$this->xmlWriterAdd->writeAttribute('name', $name);
-				$this->xmlWriterAdd->text($this->xmlentities(strval($value)));
+				$this->xmlWriterAdd->text(strval($value));
 				$this->xmlWriterAdd->endElement();
 			}
 		}
@@ -622,17 +622,6 @@ class indexer_SolrManager
 			throw new IndexException(__METHOD__ . "Unexpected Server reply (URL = " . $this->getBaseURL() . $this->getTask() . ") data = " . $data);
 		}
 		return $data;
-	}
-	
-	/**
-	 * Converts to xml entities (borrowed from SolrUpdate.php)
-	 *
-	 * @param String $string
-	 * @return String
-	 */
-	private function xmlentities($string)
-	{
-		return str_replace(array('&', '<', '>', '"'), array('&amp;', '&lt;', '&gt;', '&quot;'), $string);
 	}
 	
 	/**

--- a/libs/mvc/ChangeController.class.php
+++ b/libs/mvc/ChangeController.class.php
@@ -32,6 +32,11 @@ class controller_ChangeController extends HttpController
 
 	public function dispatch()
 	{
+		$clusterScale = ModuleService::getInstance()->moduleExists("modules_clusterscale");
+		if ($clusterScale)
+		{
+			$this->setRequestContextMode();
+		}
 		// Handle auto-login.
 		$us = users_UserService::getInstance();
 		if (is_null($us->getCurrentFrontEndUser()) && isset($_COOKIE[self::AUTO_LOGIN_COOKIE]))
@@ -57,7 +62,10 @@ class controller_ChangeController extends HttpController
 		}
 		
 		$this->setLangFromRequest();
-		$this->setRequestContextMode();
+		if (!$clusterScale)
+		{
+			$this->setRequestContextMode();
+		}
 		parent::dispatch();
 	}
 

--- a/persistentdocument/PersistentProviderMySql.class.php
+++ b/persistentdocument/PersistentProviderMySql.class.php
@@ -2271,6 +2271,7 @@ class f_persistentdocument_DocumentQueryBuilder
 	private $aliasCount = 0;
 	private $relationAliasCount = 0;
 	private $aliasByPath = array();
+	private $modelByPath = array();
 	private $currentPropertyPath = array();
 	private $groupBy = array();
 	private $having = array();
@@ -2365,7 +2366,9 @@ class f_persistentdocument_DocumentQueryBuilder
 			if (!is_null($propertyName))
 			{
 				$this->currentPropertyPath[] = $propertyName;
-				$this->aliasByPath[join('.', $this->currentPropertyPath)] = $this->getTableAlias();
+				$fullPath = join('.', $this->currentPropertyPath);
+				$this->aliasByPath[$fullPath] = $this->getTableAlias();
+				$this->modelByPath[$fullPath] = $model;
 			}
 		}
 	}
@@ -2507,6 +2510,7 @@ class f_persistentdocument_DocumentQueryBuilder
 			{
 				throw new Exception("Could not resolve $propertyName. Did you made any criteria ?");
 			}
+
 			$model = $this->getModel();
 			foreach ($propInfo as $propName)
 			{
@@ -2517,7 +2521,16 @@ class f_persistentdocument_DocumentQueryBuilder
 				}
 				if ($prop === null || !$prop->isDocument())
 				{
-					throw new Exception("$propName is not a document property");
+					$propModelName = join(".", $propInfo);
+					if (isset($this->modelByPath[$propModelName]))
+					{
+						$model = $this->modelByPath[$propModelName];
+						break;
+					}
+					else
+					{
+						throw new Exception("$propName is not a document property ");
+					}
 				}
 				$model = f_persistentdocument_PersistentDocumentModel::getInstanceFromDocumentModelName($prop->getType());
 			}


### PR DESCRIPTION
http://www.rbschange.fr/tickets/ticket/?rbsParam[cmpref]=80604

lors de l'appel à changescriptexec.php, une erreur "Invalid signature" est généré, si les arguments de l'appel contiennent les valeurs NULL ou les tableaux vides.

L'erreur vient du comportement de la fonction http_build_query qui ignore les valeurs NULL et les tableaux vides. De ce fait les paramètres POST utilisés pour le calcul de la signature oauth ne sont pas les mêmes du côté client et du côté serveur.
