### PR TITLE
Only display errors in development mode

### DIFF
--- a/service/LoggingService.class.php
+++ b/service/LoggingService.class.php
@@ -74,7 +74,9 @@ class LoggingService extends BaseService
 	 */
 	public function registerErrorHandler()
 	{
-		ini_set('display_errors', 1);
+		if (Framework::inDevelopmentMode()) {
+			ini_set('display_errors', 1);
+		}
 		
 		$this->errortype = array (
 			E_ERROR              => 'E_ERROR',


### PR DESCRIPTION
Currently, PHP errors are always displayed, including on production environments, which should not be the case.
